### PR TITLE
Values: Configure PodDisruptionBudget.

### DIFF
--- a/helm/aws-load-balancer-controller/values.schema.json
+++ b/helm/aws-load-balancer-controller/values.schema.json
@@ -180,7 +180,12 @@
             "type": "object"
         },
         "podDisruptionBudget": {
-            "type": "object"
+            "type": "object",
+            "properties": {
+                "minAvailable": {
+                    "type": "integer"
+                }
+            }
         },
         "podLabels": {
             "type": "object"

--- a/helm/aws-load-balancer-controller/values.yaml
+++ b/helm/aws-load-balancer-controller/values.yaml
@@ -232,8 +232,9 @@ defaultTags: {}
 
 # podDisruptionBudget specifies the disruption budget for the controller pods.
 # Disruption budget will be configured only when the replicaCount is greater than 1
-podDisruptionBudget: {}
-#  maxUnavailable: 1
+podDisruptionBudget:
+  minAvailable: 1
+  # maxUnavailable: 1
 
 # externalManagedTags is the list of tag keys on AWS resources that will be managed externally
 externalManagedTags: []


### PR DESCRIPTION
Prevents the admission web hook from being unavailable during cluster maintenances and fixes https://github.com/giantswarm/giantswarm/issues/21134.