### PR TITLE
Values: Configure PodDisruptionBudget.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Enable PodDisruptionBudget to prevent unavailability of the admission webhook during cluster maintenances.
+
 ## [1.1.0] - 2022-03-17
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ There are 3 ways to install this app onto a workload cluster.
 ## Configuring
 Additionally to the IAM role, the region (e.g. eu-west-1) and the VPC ID are required.
 
-By default, a PodDisruptionBudget is configured so the admission webhook does not become unreachable, possibly blocking scheduling other pods or cluster maintenances.
+By default, a [PodDisruptionBudget](https://kubernetes.io/docs/tasks/run-application/configure-pdb) is configured so the admission webhook does not become unreachable, possibly blocking scheduling other pods or cluster maintenances.
 
 ### values.yaml
 **This is an example of a values file you could upload using our web interface.**

--- a/README.md
+++ b/README.md
@@ -36,16 +36,25 @@ There are 3 ways to install this app onto a workload cluster.
 ## Configuring
 Additionally to the IAM role, the region (e.g. eu-west-1) and the VPC ID are required.
 
+By default, a PodDisruptionBudget is configured so the admission webhook does not become unreachable, possibly blocking scheduling other pods or cluster maintenances.
+
 ### values.yaml
 **This is an example of a values file you could upload using our web interface.**
 ```
-region: eu-west-1
+# RBAC
 serviceAccount:
     create: true
+
+# Deployment
 podAnnotations:
     iam.amazonaws.com/role: AWSLoadBalancerControllerIAMRole # Will be picked up by KIAM to associate the pod with the given role
 vpcId: vpc-0c7dc1da1ca5b1819
+region: eu-west-1
 
+# PodDisruptionBudget
+podDisruptionBudget:
+  minAvailable: 1
+  # maxUnavailable: 1
 ```
 
 See our [full reference page on how to configure applications](https://docs.giantswarm.io/app-platform/app-configuration/) for more details.

--- a/README.md
+++ b/README.md
@@ -41,10 +41,6 @@ By default, a [PodDisruptionBudget](https://kubernetes.io/docs/tasks/run-applica
 ### values.yaml
 **This is an example of a values file you could upload using our web interface.**
 ```
-# RBAC
-serviceAccount:
-    create: true
-
 # Deployment
 podAnnotations:
     iam.amazonaws.com/role: AWSLoadBalancerControllerIAMRole # Will be picked up by KIAM to associate the pod with the given role

--- a/README.md
+++ b/README.md
@@ -50,11 +50,6 @@ podAnnotations:
     iam.amazonaws.com/role: AWSLoadBalancerControllerIAMRole # Will be picked up by KIAM to associate the pod with the given role
 vpcId: vpc-0c7dc1da1ca5b1819
 region: eu-west-1
-
-# PodDisruptionBudget
-podDisruptionBudget:
-  minAvailable: 1
-  # maxUnavailable: 1
 ```
 
 See our [full reference page on how to configure applications](https://docs.giantswarm.io/app-platform/app-configuration/) for more details.

--- a/helm/aws-load-balancer-controller/values.schema.json
+++ b/helm/aws-load-balancer-controller/values.schema.json
@@ -180,7 +180,12 @@
             "type": "object"
         },
         "podDisruptionBudget": {
-            "type": "object"
+            "type": "object",
+            "properties": {
+                "minAvailable": {
+                    "type": "integer"
+                }
+            }
         },
         "podLabels": {
             "type": "object"

--- a/helm/aws-load-balancer-controller/values.yaml
+++ b/helm/aws-load-balancer-controller/values.yaml
@@ -232,8 +232,9 @@ defaultTags: {}
 
 # podDisruptionBudget specifies the disruption budget for the controller pods.
 # Disruption budget will be configured only when the replicaCount is greater than 1
-podDisruptionBudget: {}
-#  maxUnavailable: 1
+podDisruptionBudget:
+  minAvailable: 1
+  # maxUnavailable: 1
 
 # externalManagedTags is the list of tag keys on AWS resources that will be managed externally
 externalManagedTags: []


### PR DESCRIPTION
Prevents the admission web hook from being unavailable during cluster maintenances and fixes https://github.com/giantswarm/giantswarm/issues/21134.

- [x] Test app update: Deploy 1.1.0 and edit app CR to use commit hash.
- [x] Test PodDisruptionBudget: Drain nodes.
- [x] Test cluster upgrade.
- [x] Update README.md.