### PR TITLE
Set minimum CPU to 50m

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Set minimum CPU to `50m` in the VPA.
+
 ## [1.3.4] - 2023-08-28
 
 ### Fixed

--- a/helm/aws-load-balancer-controller/templates/vpa.yaml
+++ b/helm/aws-load-balancer-controller/templates/vpa.yaml
@@ -12,6 +12,8 @@ spec:
     - containerName: {{ .Chart.Name }}
       controlledValues: RequestsAndLimits
       mode: Auto
+      minAllowed:
+        cpu: 50m
   targetRef:
     apiVersion: apps/v1
     kind: Deployment


### PR DESCRIPTION
Yesterday we got paged because containerd couldn't create the container for this controller when very little CPU was set by VPA, so I'm adding a minimum to workaround that problem.