### PR TITLE
Add `Ingress` network policy to make the app work in `kube-system` na…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add `Ingress` network policy to make the app work in `kube-system` namespace.
+
 ## [1.6.0] - 2024-02-01
 
 ### Changed

--- a/helm/aws-load-balancer-controller/templates/networkpolicy.yaml
+++ b/helm/aws-load-balancer-controller/templates/networkpolicy.yaml
@@ -8,8 +8,15 @@ metadata:
 spec:
   egress:
   - {}
+  ingress:
+  - ports:
+      - port: {{ .Values.webhookBindPort | default 9443 }}
+        protocol: TCP
+      - port: {{ (split ":" .Values.metricsBindAddr)._1 | default 8080 }}
+        protocol: TCP
   podSelector:
     matchLabels:
       {{- include "aws-load-balancer-controller.selectorLabels" . | nindent 6 }}
   policyTypes:
   - Egress
+  - Ingress


### PR DESCRIPTION
…mespace.

Towards: https://github.com/giantswarm/giantswarm/issues/30225

Add `ingress` to networkpolicy to make app compatible with kube-system namespace