### PR TITLE
Update PolicyExceptions to v2beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update Kyverno PolicyExceptions to v2 and fallback to v2beta1.
+
 ## [1.6.1] - 2024-03-12
 
 ### Fixed

--- a/helm/aws-load-balancer-controller/templates/pss-exceptions.yaml
+++ b/helm/aws-load-balancer-controller/templates/pss-exceptions.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.global.podSecurityStandards.enforced }}
-apiVersion: kyverno.io/v2alpha1
+{{ if .Capabilities.APIVersions.Has "kyverno.io/v2/PolicyException" -}}
+apiVersion: kyverno.io/v2
+{{- else }}
+apiVersion: kyverno.io/v2beta1
+{{- end }}
 kind: PolicyException
 metadata:
   name: {{ include "aws-load-balancer-controller.fullname" . }}


### PR DESCRIPTION
### Related issue: https://github.com/giantswarm/giantswarm/issues/30726

## Description

We need to update the PolicyExceptions apiVersion to v2beta1 as v2alpha1 is being removed in the next Kyverno release.