### PR TITLE
Get rid of the legacy in-house slo framework label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Get rid of legacy in-house slo framework.
+
 ## [2.1.0] - 2024-09-23
 
 ### Changed

--- a/helm/aws-load-balancer-controller/templates/deployment.yaml
+++ b/helm/aws-load-balancer-controller/templates/deployment.yaml
@@ -10,7 +10,6 @@ metadata:
   labels:
     {{- include "aws-load-balancer-controller.labels" . | nindent 4 }}
     giantswarm.io/service-type: "managed"
-    giantswarm.io/monitoring_basic_sli: "true"
 spec:
   replicas: {{ .Values.replicaCount }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}


### PR DESCRIPTION
Towards giantswarm/giantswarm#31095

Getting rid of the legacy in-house slo framework

