### PR TITLE
Set our own home URL in Chart.yaml

### DIFF
--- a/helm/aws-load-balancer-controller/Chart.yaml
+++ b/helm/aws-load-balancer-controller/Chart.yaml
@@ -3,7 +3,7 @@ name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
 version: 1.8.3
 appVersion: v2.8.3
-home: https://github.com/aws/eks-charts
+home: https://github.com/giantswarm/aws-load-balancer-controller-app
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 annotations:
   application.giantswarm.io/team: phoenix


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3982

We need one URL to our app repository in order to be able to match deployments of this chart with the source repository in Backstage