### PR TITLE
Use .Chart.AppVersion instead of .Chart.Version

### DIFF
--- a/.abs/main.yaml
+++ b/.abs/main.yaml
@@ -1,3 +1,4 @@
+replace-app-version-with-git: true
 replace-chart-version-with-git: true
 generate-metadata: true
 chart-dir: ./helm/aws-lb-controller

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Use `.Chart.AppVersion` instead of `.Chart.Version` for OCIRepository tag.
+
 ## [5.0.1] - 2026-01-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update ABS config to replace `.appVersion` in Chart.yaml with version detected by ABS.
+
 ### Fixed
 
 - Use `.Chart.AppVersion` instead of `.Chart.Version` for OCIRepository tag.

--- a/helm/aws-lb-controller-bundle/templates/helmreleases.yaml
+++ b/helm/aws-lb-controller-bundle/templates/helmreleases.yaml
@@ -10,7 +10,7 @@ spec:
   url: {{ .Values.ociRepositoryUrl }}
   interval: 1h
   ref:
-    tag: {{ .Chart.Version }}
+    tag: {{ .Chart.AppVersion }}
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease


### PR DESCRIPTION
## Summary

- Use `.Chart.AppVersion` instead of `.Chart.Version` for the OCIRepository tag
- The chart version can contain build metadata (e.g., `+1234567`) which OCI registries don't support in tags

Towards https://github.com/giantswarm/roadmap/issues/4194