### PR TITLE
Update chart icon URL to Giant Swarm hosted SVG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update chart icon URL to use Giant Swarm hosted SVG icon.
+
 ## [5.0.3] - 2026-02-27
 
 ### Changed

--- a/helm/aws-lb-controller-bundle/Chart.yaml
+++ b/helm/aws-lb-controller-bundle/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "5.0.3"
 name: aws-lb-controller-bundle
 description: AWS Load Balancer Controller Bundle with Crossplane resources
-icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
+icon: https://s.giantswarm.io/app-icons/aws/2/light.svg
 version: "5.0.3"
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/giantswarm/aws-load-balancer-controller-app

--- a/helm/aws-load-balancer-controller/Chart.yaml
+++ b/helm/aws-load-balancer-controller/Chart.yaml
@@ -4,7 +4,7 @@ description: AWS Load Balancer Controller Helm chart for Kubernetes
 version: 3.0.0
 appVersion: v3.0.0
 home: https://github.com/aws/eks-charts
-icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
+icon: https://s.giantswarm.io/app-icons/aws/2/light.svg
 annotations:
   application.giantswarm.io/team: phoenix
 sources:


### PR DESCRIPTION
## Summary
- Replace the deprecated `https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png` icon URL with `https://s.giantswarm.io/app-icons/aws/2/light.svg` in both Chart.yaml files
- Updated `helm/aws-lb-controller-bundle/Chart.yaml` and `helm/aws-load-balancer-controller/Chart.yaml`
- Added changelog entry under `[Unreleased]`

## Test plan
- [x] Verify the new icon URL resolves correctly
- [ ] Confirm charts render properly with the new SVG icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)