### PR TITLE
feat(helm): add optional secret injection via valuesFromSecret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `valuesFromSecret` value to optionally inject a Secret as an additional `valuesFrom` source in the HelmRelease.
+
 ## [5.1.0] - 2026-03-25
 
 ### Changed

--- a/helm/aws-lb-controller-bundle/templates/_helpers.tpl
+++ b/helm/aws-lb-controller-bundle/templates/_helpers.tpl
@@ -138,7 +138,7 @@ Strips bundle-only keys and restructures into:
 {{- $workload := dict -}}
 
 {{/* Keys that are bundle-only and must NOT be forwarded to the workload chart */}}
-{{- $bundleOnlyKeys := list "bundleNameOverride" "fullBundleNameOverride" "ociRepositoryUrl" -}}
+{{- $bundleOnlyKeys := list "bundleNameOverride" "fullBundleNameOverride" "ociRepositoryUrl" "valuesFromSecret" -}}
 
 {{/* Keys that are GS extras — forwarded at the top level of the workload chart */}}
 {{- $extrasKeys := list "verticalPodAutoscaler" "global" "networkPolicy" -}}

--- a/helm/aws-lb-controller-bundle/templates/helmreleases.yaml
+++ b/helm/aws-lb-controller-bundle/templates/helmreleases.yaml
@@ -43,3 +43,8 @@ spec:
       name: {{ $clusterName }}-aws-load-balancer-controller-config
       valuesKey: values
       optional: false
+    {{- if .Values.valuesFromSecret }}
+    - kind: Secret
+      name: {{ .Values.valuesFromSecret }}
+      optional: false
+    {{- end }}

--- a/helm/aws-lb-controller-bundle/values.schema.json
+++ b/helm/aws-lb-controller-bundle/values.schema.json
@@ -12,6 +12,9 @@
         "ociRepositoryUrl": {
             "type": "string"
         },
+        "valuesFromSecret": {
+            "type": "string"
+        },
         "image": {
             "type": "object",
             "additionalProperties": true,

--- a/helm/aws-lb-controller-bundle/values.yaml
+++ b/helm/aws-lb-controller-bundle/values.yaml
@@ -7,6 +7,9 @@ fullBundleNameOverride: ""
 
 ociRepositoryUrl: oci://gsoci.azurecr.io/charts/giantswarm/aws-load-balancer-controller
 
+# Optional: name of a Secret to inject as additional values into the HelmRelease
+valuesFromSecret: ""
+
 # =============================================================================
 # UPSTREAM — Controller values (forwarded under "upstream:" to the workload chart)
 # =============================================================================


### PR DESCRIPTION
## Summary

- Adds a new `valuesFromSecret` value (default: `""`) that, when set, injects the named Secret as an additional `valuesFrom` source in the HelmRelease.
- The key is excluded from being forwarded to the workload chart.

## Use case

This is intended for installations where a proxy is required. In those environments, proxy configuration (e.g. `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`) can be stored in a Secret and injected into the controller's values without hardcoding them in the bundle chart.

## Test plan

- [ ] Deploy with `valuesFromSecret` unset — behaviour unchanged
- [ ] Deploy with `valuesFromSecret` pointing to an existing Secret — Secret is picked up as a values source by Flux