### PR TITLE
Remove PSP-related leftovers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Removed `global.podSecurityStandards.enforced` helm value. The Kyverno `PolicyException` in `pss-exceptions.yaml` is now rendered unconditionally.
+
 ## [5.2.0] - 2026-05-27
 
 ### Added

--- a/helm/aws-lb-controller-bundle/templates/_helpers.tpl
+++ b/helm/aws-lb-controller-bundle/templates/_helpers.tpl
@@ -132,7 +132,6 @@ Strips bundle-only keys and restructures into:
   upstream:
     <all upstream controller values>
   verticalPodAutoscaler: ...
-  global: ...
 */}}
 {{- define "giantswarm.workloadValues" -}}
 {{- $workload := dict -}}
@@ -141,7 +140,7 @@ Strips bundle-only keys and restructures into:
 {{- $bundleOnlyKeys := list "bundleNameOverride" "fullBundleNameOverride" "ociRepositoryUrl" "valuesFromSecret" -}}
 
 {{/* Keys that are GS extras — forwarded at the top level of the workload chart */}}
-{{- $extrasKeys := list "verticalPodAutoscaler" "global" "networkPolicy" -}}
+{{- $extrasKeys := list "verticalPodAutoscaler" "networkPolicy" -}}
 
 {{/* Keys that need special transformation */}}
 {{- $specialKeys := list "image" "clusterName" -}}

--- a/helm/aws-lb-controller-bundle/values.schema.json
+++ b/helm/aws-lb-controller-bundle/values.schema.json
@@ -44,21 +44,6 @@
                     "type": "boolean"
                 }
             }
-        },
-        "global": {
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-                "podSecurityStandards": {
-                    "type": "object",
-                    "additionalProperties": true,
-                    "properties": {
-                        "enforced": {
-                            "type": "boolean"
-                        }
-                    }
-                }
-            }
         }
     }
 }

--- a/helm/aws-lb-controller-bundle/values.yaml
+++ b/helm/aws-lb-controller-bundle/values.yaml
@@ -61,7 +61,3 @@ configureDefaultAffinity: true
 
 verticalPodAutoscaler:
   enabled: true
-
-global:
-  podSecurityStandards:
-    enforced: false

--- a/helm/aws-load-balancer-controller/templates/pss-exceptions.yaml
+++ b/helm/aws-load-balancer-controller/templates/pss-exceptions.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.podSecurityStandards.enforced }}
 {{ if .Capabilities.APIVersions.Has "kyverno.io/v2/PolicyException" -}}
 apiVersion: kyverno.io/v2
 {{- else }}
@@ -31,4 +30,3 @@ spec:
             - {{ .Release.Namespace }}
           names:
             - {{ include "extras.fullname" . }}*
-{{- end }}

--- a/helm/aws-load-balancer-controller/values.schema.json
+++ b/helm/aws-load-balancer-controller/values.schema.json
@@ -27,21 +27,6 @@
                 }
             }
         },
-        "global": {
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-                "podSecurityStandards": {
-                    "type": "object",
-                    "additionalProperties": true,
-                    "properties": {
-                        "enforced": {
-                            "type": "boolean"
-                        }
-                    }
-                }
-            }
-        },
         "upstream": {
             "type": "object",
             "additionalProperties": true

--- a/helm/aws-load-balancer-controller/values.yaml
+++ b/helm/aws-load-balancer-controller/values.yaml
@@ -11,10 +11,6 @@ networkPolicy:
 verticalPodAutoscaler:
   enabled: true
 
-global:
-  podSecurityStandards:
-    enforced: false
-
 # =============================================================================
 # UPSTREAM — Values passed to the upstream sub-chart (alias: upstream)
 # =============================================================================


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/35177

- `helm/aws-load-balancer-controller/templates/pss-exceptions.yaml`: drop the `{{- if .Values.global.podSecurityStandards.enforced }}` guard so the `PolicyException` always renders.
- `helm/aws-load-balancer-controller/values.yaml`, `helm/aws-lb-controller-bundle/values.yaml`: remove the `global.podSecurityStandards` block.
- `helm/aws-load-balancer-controller/values.schema.json`, `helm/aws-lb-controller-bundle/values.schema.json`: remove the `global` property.
- `helm/aws-lb-controller-bundle/templates/_helpers.tpl`: drop `global` from `\$extrasKeys` in `giantswarm.workloadValues`.
