### PR TITLE
chore: remove `ct_config` from push-to-app-catalog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,6 @@ workflows:
           app_catalog: giantswarm-catalog
           app_catalog_test: giantswarm-test-catalog
           chart: aws-load-balancer-controller
-          ct_config: ".circleci/ct-config.yaml"
           explicit_allow_chart_name_mismatch: true
           <<: *job_filters
 
@@ -31,7 +30,6 @@ workflows:
           app_catalog: giantswarm-catalog
           app_catalog_test: giantswarm-test-catalog
           chart: aws-lb-controller-bundle
-          ct_config: ".circleci/ct-config.yaml"
           explicit_allow_chart_name_mismatch: true
           <<: *job_filters
 
@@ -42,7 +40,6 @@ workflows:
           app_catalog: control-plane-catalog
           app_catalog_test: control-plane-test-catalog
           chart: aws-lb-controller-bundle
-          ct_config: ".circleci/ct-config.yaml"
           explicit_allow_chart_name_mismatch: true
           <<: *job_filters
 


### PR DESCRIPTION
`ct_config` has been **ignored by architect-orb since v9.0.0 (when the `helm-lint` step it controlled was removed)** — passing it currently does nothing.

It is removed in the upcoming **architect-orb v10.0.0**. Because CircleCI fails config compilation on unknown job arguments, any repo still passing it will break the moment Renovate bumps the orb to v10. Merging this beforehand makes that bump a no-op for you.

No behaviour change: the parameter is already a no-op today.

Part of giantswarm/roadmap#4066